### PR TITLE
Add x86_64-linux platform to Gemfile.lock for Heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.0-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.3)
     public_suffix (5.0.1)
     puma (5.6.5)
@@ -208,6 +210,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
 bundle lock --add-platform x86_64-linux