### PR TITLE
ログアウト追加_#28

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,11 +10,14 @@
         <%= link_to '会員登録', new_user_path, class: 'btn btn-primary btn-sm fs-sm rounded d-none d-lg-inline-flex' %>
       </div>
     </div>
+    <% if logged_in? %>
+      <%= link_to 'ログアウト', logout_path, class: 'btn btn-secondary btn-sm fs-sm rounded d-none d-lg-inline-flex', data: { turbo_method: :delete} %>
+    <% else %>
       <div class="form-check form-switch mode-switch pe-lg-1 ms-auto me-4" data-bs-toggle="mode">
         <%= link_to 'ログイン', login_path, class: 'btn btn-secondary btn-sm fs-sm rounded d-none d-lg-inline-flex' %>
       </div>
         <%= link_to '会員登録', new_user_path, class: 'btn btn-primary btn-sm fs-sm rounded d-none d-lg-inline-flex' %>
       </div>
-    </div>
+    <% end %>
   </div>
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"
-  post 'logout' => 'user_sessions#destroy', :as => :logout
+  delete 'logout' => 'user_sessions#destroy', :as => :logout
 end


### PR DESCRIPTION
[_headerへログアウトの追加]
・`<% if logged_in? %>`sorceryのメソッドでログイン済みかを判断
・ログアウトリンクの追加
`<%= link_to 'ログアウト', logout_path, class: 'btn btn-secondary btn-sm fs-sm rounded d-none d-lg-inline-flex', data: { turbo_method: :delete} %>`

Rails7公式ガイドでは linkよりbutton 
> HTTPメソッドの変更は、data-turbo-method属性をリンクに追加する方法の他に、Railsのbutton_toヘルパーでもできます。なお実際には、アクセシビリティの観点から、非GETアクションには（リンクではなく）ボタンとフォームを用いるのが望ましい方法です。

https://railsguides.jp/working_with_javascript_in_rails.html#http%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89

削除するためにDeleteボタンを使う際は注意が必要な記事もあるので注意しながら実装する。
https://qiita.com/jnchito/items/5c41a7031404c313da1f#link_to%E3%81%AEmethod%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E6%9B%B8%E3%81%8D%E6%96%B9%E3%81%8C%E5%A4%89%E3%82%8F%E3%81%A3%E3%81%9F

