### PR TITLE
Event #16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,4 @@ gem "dotenv-rails", "~> 2.7"
 gem "line-bot-api", "~> 1.12"
 # LINEログイン機能を実装するためのgem
 gem 'omniauth-line'
+gem 'enum_help', '~> 0.0.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.12.0)
     faraday (2.7.5)
       faraday-net_http (>= 2.0, < 3.1)
@@ -270,6 +272,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails (~> 2.7)
+  enum_help (~> 0.0.15)
   jbuilder
   jsbundling-rails
   line-bot-api (~> 1.12)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,12 @@ class ApplicationController < ActionController::Base
     private
 
     def authorize_user_family_access
-        target_family = @family || @user.family
-        if current_user && current_user.family != target_family
-            flash[:alert] = 'アクセス権限がありません'
-            redirect_to families_path
+        if current_user 
+            target_family = @family || current_user.family
+            if current_user.family != target_family
+                flash[:alert] = 'アクセス権限がありません'
+                redirect_to families_path
+            end
         end
     end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,47 @@
+class EventsController < ApplicationController
+  before_action :require_login
+  before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_user_family_access, only: %i[show edit update]
+
+  def new
+    @event = Event.new
+  end
+
+  def create
+    @event = current_user.events.build(event_params)
+    if @event.save
+      redirect_to @event, notice: 'Event was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @event.update(event_params)
+      redirect_to @event, notice: 'Event was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @event.destroy
+    redirect_to events_url, notice: 'Event was successfully destroyed.'
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:id])
+  end
+
+  def event_params
+    params.require(:event).permit(:event_type, :title, :start_date, :end_date, :content, :visibility)
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,32 +1,39 @@
 class EventsController < ApplicationController
   before_action :require_login
   before_action :set_event, only: [:show, :edit, :update, :destroy]
-  before_action :authorize_user_family_access, only: %i[show edit update]
 
   def new
     @event = Event.new
   end
 
   def create
-    @event = current_user.events.build(event_params)
-    if @event.save
-      redirect_to @event, notice: 'Event was successfully created.'
+    event = Event.new(event_params)
+    event.user = current_user
+    if event.save
+      flash[:notice] = 'Event was successfully created.'
+      redirect_to event
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
-  def show
+
+  def show;
   end
 
-  def edit
+  def edit;
+  end
+
+  def index
+    @events = Event.all
   end
 
   def update
     if @event.update(event_params)
-      redirect_to @event, notice: 'Event was successfully updated.'
+      flash[:notice] = 'Event was successfully updated.'
+      redirect_to event_path(@event)
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   before_action :require_login
   before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_user_family_access, only: %i[show edit update ]
 
   def new
     @event = Event.new
@@ -18,14 +19,22 @@ class EventsController < ApplicationController
   end
 
 
-  def show;
+  def show
+    unless @event.user.family == current_user.family
+      flash[:alert] = 'アクセス権限がありません'
+      redirect_to families_path
+    end
   end
 
-  def edit;
+  def edit
+    unless @event.user.family == current_user.family
+      flash[:alert] = 'アクセス権限がありません'
+      redirect_to families_path
+    end
   end
 
   def index
-    @events = Event.all
+    @events = Event.where(user: current_user.family.users)
   end
 
   def update

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/javascript/controllers/confirm_controller.js
+++ b/app/javascript/controllers/confirm_controller.js
@@ -9,6 +9,14 @@ export default class extends Controller {
       e.target.closest('form').submit();
     }
   }
+
+  confirmDelete(e) {
+    e.preventDefault()
+    
+    if (window.confirm("削除してよろしいですか")) {
+      e.target.closest('form').submit();
+    }
+  }
 }
 
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("flash", FlashController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import VisibilityController from "./visibility_controller"
+application.register("visibility", VisibilityController)

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="visibility"
+export default class extends Controller {
+  static targets = ["select", "checkboxes"]
+
+  connect() {
+    this.updateCheckboxes()
+  }
+
+  updateCheckboxes() {
+    if (this.selectTarget.value == "partial") {
+      this.checkboxesTarget.style.display = "block";
+    } else {
+      this.checkboxesTarget.style.display = "none";
+      }
+    }
+}

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,17 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+
+  def self.human_attribute_enum_value(attr_name, value)
+    return if value.blank?
+    human_attribute_name("#{attr_name}.#{value}")
+  end
+  
+  def human_attribute_enum(attr_name)
+    self.class.human_attribute_enum_value(attr_name, self.send("#{attr_name}"))
+  end
+
+  def self.enum_options_for_select(attr_name)
+    self.send(attr_name.to_s.pluralize).map { |k, _| [self.human_attribute_enum_value(attr_name, k), k] }.to_h
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ApplicationRecord
   belongs_to :user
-  enum event_type: { birthday: 0, anniversary: 1, other: 2 }, _prefix: true, _suffix: true, _default: 'other'
-  enum visibility: { everyone: 0, partial: 1, draft: 2 }, _prefix: true, _suffix: true, _default: 'draft'
+  enum event_type: { birthday: 0, anniversary: 1, other: 2 }, _prefix: true, _suffix: true
+  enum visibility: { everyone: 0, partial: 1, draft: 2 }, _prefix: true, _suffix: true
 
   validates :title, presence: true
   validates :start_date, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,10 +1,28 @@
 class Event < ApplicationRecord
-  belongs_to :user
+
+  # アソシエーション
+  has_many :event_visibilities, dependent: :destroy
+  has_many :visible_to_users, through: :event_visibilities, source: :user
   enum event_type: { birthday: 0, anniversary: 1, other: 2 }, _prefix: true, _suffix: true
   enum visibility: { everyone: 0, partial: 1, draft: 2 }, _prefix: true, _suffix: true
-
+  
+  # バリデーション
   validates :title, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
-  # 他の必要なバリデーションを追加します
+  
+  # イベントの公開範囲を判定するメソッド
+  def visible_to(user)
+    case visibility
+    when 'everyone'
+      true
+    when 'partial'
+      # partialの場合には、イベントと関連があるユーザーのみがアクセスできるようにします。
+      visible_to_users.include?(user)
+    when 'draft'
+      user_id == user.id
+    else
+      false
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,10 @@
+class Event < ApplicationRecord
+  belongs_to :user
+  enum event_type: { birthday: 0, anniversary: 1, other: 2 }
+  enum visibility: { everyone: 0, partial: 1, draft: 2 }
+
+  validates :title, presence: true
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  # 他の必要なバリデーションを追加します
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ApplicationRecord
   belongs_to :user
-  enum event_type: { birthday: 0, anniversary: 1, other: 2 }
-  enum visibility: { everyone: 0, partial: 1, draft: 2 }
+  enum event_type: { birthday: 0, anniversary: 1, other: 2 }, _prefix: true, _suffix: true, _default: 'other'
+  enum visibility: { everyone: 0, partial: 1, draft: 2 }, _prefix: true, _suffix: true, _default: 'draft'
 
   validates :title, presence: true
   validates :start_date, presence: true

--- a/app/models/event_visibility.rb
+++ b/app/models/event_visibility.rb
@@ -1,0 +1,4 @@
+class EventVisibility < ApplicationRecord
+  belongs_to :event
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,18 +1,24 @@
 class User < ApplicationRecord
   # sorceryの設定
   authenticates_with_sorcery!
-  has_many :authentications, dependent: :destroy
-  accepts_nested_attributes_for :authentications
 
+  # アソシエーション
+  has_many :authentications, dependent: :destroy
+  has_many :events
   belongs_to :family, optional: true
   has_one :administered_family, class_name: 'Family', foreign_key: :admin_id
 
+  # ネストした属性
+  accepts_nested_attributes_for :authentications
+
+  # バリデーション
   validates :name, presence: true, length: { maximum: 50, allow_blank: true}
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, confirmation: true, length: { minimum:3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   
   private
+
   # ユーザーが所属しているファミリーを作成する
   def create_family(params)
     if administered_families.exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,11 @@ class User < ApplicationRecord
 
   # アソシエーション
   has_many :authentications, dependent: :destroy
-  has_many :events
+  has_many :event_visibilities, dependent: :destroy 
+  has_many :visible_events, through: :event_visibilities, source: :event
   belongs_to :family, optional: true
   has_one :administered_family, class_name: 'Family', foreign_key: :admin_id
+
 
   # ネストした属性
   accepts_nested_attributes_for :authentications

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,55 @@
+<%= bootstrap_form_with model: event do |form| %>
+  <% if event.errors.any? %>
+    <div class="alert alert-danger">
+      <h2><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</h2>
+      <ul>
+        <% event.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="row">
+    <div class="col-sm-10">
+      <p class="card-text fs-sm mb-2">
+        <%= form.select :event_type, Event.enum_options_for_select(:event_type), { include_blank: '選択してください' }, class: "form-select" %>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-10">
+      <p class="card-text fs-sm mb-2">
+        <%= form.text_field :title, class: "form-control" %>
+      </p>
+    </div>
+  </div>
+  <div class="row" data-controller="date-picker">
+    <div class="col-sm-10">
+      <p class="card-text fs-sm mb-2">
+        <%= form.label :start_date, class: 'form-label' %>
+        <%= form.date_field :start_date, class: "form-control", label_as_placeholder: true %>
+      </p>
+    </div>
+    <div class="col-sm-10">
+      <p class="card-text fs-sm mb-2">
+        <%= form.label :end_date, class: 'form-label' %>
+        <%= form.date_field :end_date, class: "form-control", label_as_placeholder: true %>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-10">
+      <p class="card-text fs-sm mb-2">
+        <%= form.text_area :content, class: "form-control", rows: 3 %>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-sm-10">
+      <p class="card-text fs-sm mb-2">
+        <%= form.select :visibility, Event.enum_options_for_select(:visibility), { include_blank: '選択してください' }, class: "form-select" %>
+      </p>
+    </div>
+  </div>
+  <%= form.submit "保存する", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -44,12 +44,21 @@
       </p>
     </div>
   </div>
-  <div class="row">
+  <div class="row" data-controller="visibility">
     <div class="col-sm-10">
       <p class="card-text fs-sm mb-2">
-        <%= form.select :visibility, Event.enum_options_for_select(:visibility), { include_blank: '選択してください' }, class: "form-select" %>
+        <%= form.select :visibility, Event.enum_options_for_select(:visibility), { include_blank: '選択してください' }, class: "form-select", data: { visibility_target: "select", action: "change->visibility#updateCheckboxes" } %>
       </p>
+      <div data-visibility-target="checkboxes" style="display: none;">
+        <% current_user.family.users.each do |user| %>
+          <div>
+            <%= check_box_tag 'event[visible_to_user_ids][]', user.id, event.visible_to_user_ids.include?(user.id) %>
+            <%= label_tag "event_visible_to_user_ids_#{user.id}", user.name %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
+
   <%= form.submit "保存する", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag 'events' do %>
+<div class="container">
+  <div class="row justify-content-center pt-5">
+    <div class="col-lg-6 col-md-8 col-12 pt-1 pt-md-4 pb-4">
+      <div class="card">
+        <div class="card-body">
+          <h1 class="text-center text-xl-start">イベント編集</h1>
+
+          <%= render 'form', event: @event %>
+
+          <%= link_to 'Back', events_path %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,21 @@
+<%= provide(:title, t('activerecord.models.event')) %>
+
+<%= turbo_frame_tag 'events' do %>
+  <h1>Events</h1>
+
+  <% @events.each do |event| %>
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title"><%= event.title %></h5>
+        <p class="card-text"><%= event.content %></p>
+        <%= link_to t('activerecord.action.show'), event, data: { turbo_action: 'replace' } %>
+        <%= link_to t('activerecord.action.edit'), edit_event_path(event) %>
+        <%= form_with url: event_path(event), method: :delete, data: { controller: 'confirm', action: 'click->confirm#confirmDelete' } do %>
+          <%= submit_tag t('activerecord.action.destroy') %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <%= link_to t('activerecord.action.create'), new_event_path, data: { turbo_action: 'replace' } %>
+<% end %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag 'events' do %>
+    <div class="container">
+        <div class="row justify-content-center pt-5">
+            <div class="col-lg-6 col-md-8 col-12 pt-1 pt-md-4 pb-4">
+                <div class="card">
+                    <div class="card-body">
+                        <h1 class="text-center text-xl-start">イベント作成</h1>
+
+                        <%= render 'form', event: @event %>
+
+                        <%= link_to '戻る', events_path %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,36 @@
+<%= turbo_frame_tag 'events' do %>
+  <%= render 'layouts/flash' %>
+
+  <p>
+    <strong><%= t('activerecord.attributes.event.event_type') %>:</strong>
+    <%= @event.human_attribute_enum(:event_type) %>
+  </p>
+
+  <p>
+    <strong><%= t('activerecord.attributes.event.title') %>:</strong>
+    <%= @event.title %>
+  </p>
+
+  <p>
+    <strong><%= t('activerecord.attributes.event.start_date') %>:</strong>
+    <%= I18n.l(@event.start_date, formats: :long) %>
+  </p>
+
+  <p>
+    <strong><%= t('activerecord.attributes.event.end_date') %>:</strong>
+    <%= I18n.l(@event.end_date, formats: :long) %>
+  </p>
+
+  <p>
+    <strong><%= t('activerecord.attributes.event.content') %>:</strong>
+    <%= @event.content %>
+  </p>
+
+  <p>
+    <strong><%= t('activerecord.attributes.event.visibility') %>:</strong>
+    <%= @event.human_attribute_enum(:visibility) %>
+  </p>
+
+  <%= link_to 'Edit', edit_event_path(@event) %>
+  <%= link_to 'Back', events_path %>
+<% end %>

--- a/app/views/events/update.turbo_stream.erb
+++ b/app/views/events/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo.stream.replace @event %>
+<%= render_turbo_stream_flash_messages %>
+```

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,6 +13,7 @@
     <% if logged_in? %>
       <% if current_user.family.present? %>
         <%= link_to '家族情報編集', edit_family_path(current_user.family), class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex me-3' %>
+        <%= link_to 'イベント一覧', events_path, class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex me-3' %>
       <% end %>
       <%= button_to logout_path, class: 'btn btn-secondary shadow-secondary btn-sm fs-sm rounded d-none d-lg-inline-flex', method: :delete, data: { controller: 'confirm', action: 'click->confirm#confirmLogout' } do %>
         ログアウト

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -174,6 +174,13 @@ ja:
       short: "%m/%d %H:%M"
     pm: 午後
   activerecord:
+    action:
+      create: 作成
+      destroy: 削除
+      edit: 編集
+      new: 新規作成
+      show: 表示
+      update: 更新
     models:
       event: イベント
     attributes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -173,3 +173,22 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  activerecord:
+    models:
+      event: イベント
+    attributes:
+      event:
+        title: タイトル
+        start_date: 開始日
+        end_date: 終了日
+        event_type: イベント種別
+        content: 内容
+        visibility: 公開範囲
+      event/event_type:
+        birthday: 誕生日
+        anniversary: 記念日
+        other: その他
+      event/visibility:
+        everyone: 全員
+        partial: 部分公開
+        draft: 下書き

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,6 @@ Rails.application.routes.draw do
       get :accept
     end
   end
+
+  resources :events
 end

--- a/db/migrate/20230718052255_create_events.rb
+++ b/db/migrate/20230718052255_create_events.rb
@@ -1,0 +1,15 @@
+class CreateEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :events do |t|
+      t.string :event_type
+      t.string :title
+      t.datetime :start_date
+      t.datetime :end_date
+      t.text :content
+      t.string :visibility
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230720010103_change_column_type_in_events.rb
+++ b/db/migrate/20230720010103_change_column_type_in_events.rb
@@ -1,0 +1,6 @@
+class ChangeColumnTypeInEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_column :events, :event_type, 'integer USING CAST(event_type AS integer)'
+    change_column :events, :visibility, 'integer USING CAST(visibility AS integer)'
+  end
+end

--- a/db/migrate/20230727045203_create_event_visibilities.rb
+++ b/db/migrate/20230727045203_create_event_visibilities.rb
@@ -1,0 +1,10 @@
+class CreateEventVisibilities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :event_visibilities do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_20_010103) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_045203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_010103) do
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
+
+  create_table "event_visibilities", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_event_visibilities_on_event_id"
+    t.index ["user_id"], name: "index_event_visibilities_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -72,6 +81,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_010103) do
     t.index ["family_id"], name: "index_users_on_family_id"
   end
 
+  add_foreign_key "event_visibilities", "events"
+  add_foreign_key "event_visibilities", "users"
   add_foreign_key "events", "users"
   add_foreign_key "families", "users", column: "admin_id"
   add_foreign_key "invitations", "families"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_052255) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_20_010103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,12 +25,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_052255) do
   end
 
   create_table "events", force: :cascade do |t|
-    t.string "event_type"
+    t.integer "event_type"
     t.string "title"
     t.datetime "start_date"
     t.datetime "end_date"
     t.text "content"
-    t.string "visibility"
+    t.integer "visibility"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_09_080506) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_052255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_09_080506) do
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
     t.index ["user_id"], name: "index_authentications_on_user_id"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "event_type"
+    t.string "title"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.text "content"
+    t.string "visibility"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
   create_table "families", force: :cascade do |t|
@@ -59,6 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_09_080506) do
     t.index ["family_id"], name: "index_users_on_family_id"
   end
 
+  add_foreign_key "events", "users"
   add_foreign_key "families", "users", column: "admin_id"
   add_foreign_key "invitations", "families"
   add_foreign_key "users", "families"

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/event_visibilities.yml
+++ b/test/fixtures/event_visibilities.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: one
+  user: one
+
+two:
+  event: two
+  user: two

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event_type: MyString
+  title: MyString
+  start_date: 2023-07-18 14:22:55
+  end_date: 2023-07-18 14:22:55
+  content: MyText
+  visibility: MyString
+  user: one
+
+two:
+  event_type: MyString
+  title: MyString
+  start_date: 2023-07-18 14:22:55
+  end_date: 2023-07-18 14:22:55
+  content: MyText
+  visibility: MyString
+  user: two

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/event_visibility_test.rb
+++ b/test/models/event_visibility_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventVisibilityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
1. イベントモデルの作成
`bin/rails generate model Event event_type:string title:string start_date:datetime end_date:datetime content:text visibility:string user:references`
　公開設定を行う'visibility'の属性を'string'でしたため'visibility'へenumを定義した場合`visibility: nil`となり機能しない。データへの保存は数値型（["visibility", "0"]など）で行うため、型を'integer'へ変更。
    `enum visibility: { everyone: 0, partial: 1, draft: 2 }, _prefix: true, _suffix: true`
　・変更用のマイグレーションファイルを作成する　
　　`bin/rails g migration ChangeColumnTypeInEvents`
　　しかし、migrationを作成して実行すると**PostgreSQL**を使っていた場合エラーがでる。
　　ログ：`StandardError: An error has occurred, this and all later migrations canceled:`
　　　　　`PG::DatatypeMismatch: ERROR:  column "event_type" cannot be cast automatically to type integer　HINT:  You might need to specify "USING event_type::integer".`
　・change_columnメソッド内でUSING句を使用して型変換を指定する
　　`change_column :events, :visibility, 'integer USING CAST(visibility AS integer)'`

　・イベント作成、一覧、編集、詳細、削除機能の設定
　・ビューの作成
　newとeditアクションから使用する_form.html.erbの作成
　index,show.html.erbの作成
　・ルーティングの設定
　`resources :events`

2. イベント公開、一部公開、下書き機能追加
　・中間テーブル
　　UserとEventを多対多の関係へ変更し、中間テーブルEvent_visibilitiesモデルの作成。
　　`bin/rails g model EventVisible event :references user: references`
　・イベントの公開範囲をprtial（部分公開）を判断する
   　 'visible_to'モデルメソッドの定義
　・イベントコントローラの編集
　　visible_toメソッドへ変更
　　`event_params`へ`visible_to_user_ids: []`を追加する（UserIDとEventIDの紐付け）
　・viewの編集とstimulusコントローラへvisibilityを追加
　　公開範囲のUser名を表示するチェックボックスを動的に表示する
    
3. 他のFamilyのイベントへのアクセス制限
`before_action :authorize_user_family_access, only: %i[show edit update ]`


