### PR TITLE
Fix:イメージ削除機能追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,11 +27,18 @@ class UsersController < ApplicationController
     @family = @user.family
   end
 
-  def edit;
+  def edit
     if current_user != @user
       flash[:alert] = "You are not allowed to edit this user."
       redirect_to user_path(@user)
     end
+  end
+
+  def destroy_image
+    @user = User.find(params[:id])
+    @user.image.purge
+    redirect_to @user, notice: 'イメージを削除しました'
+    puts "Destroy Image Action Triggered"
   end
 
   def update

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -6,6 +6,12 @@
                     <!-- User Image -->
                     <%= image_tag(@user.image.attached? ? url_for(@user.image.variant(resize_to_limit: [400, 400])) : image_url('default.png'), class: "card-img-top") %>
                     
+                    <div class="d-flex justify-content-end">
+                        <% if @user.image.attached? %>
+                            <%= button_to '画像の削除', destroy_image_user_path(@user), method: :delete, data: { turbo_confirm: '本当に削除しますか?' }, class: 'float-right' %>
+                        <% end %>
+                    </div>
+
                     <!-- User Details -->
                     <div class="card-body">
                         <h5 class="card-title"><%= @user.name %></h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root 'tops#index'
 
-  resources :users, except: %i[index destroy]
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"
   delete 'logout' => 'user_sessions#destroy', :as => :logout
@@ -14,6 +13,11 @@ Rails.application.routes.draw do
   get 'oauth/callback' => 'oauths#callback' 
   get 'oauth/:provider' => 'oauths#oauth', :as => :auth_at_provider
 
+  resources :users, except: %i[index] do
+    member do
+        delete :destroy_image
+    end
+  end
 
   resources :families, only: %i[index new create show edit update] do
     resources :invitations, only: %i[new create]


### PR DESCRIPTION
UserImageの削除機能追加
1. destroy_imageアクションの追加　users_controller.rb

```
  def destroy_image
    @user = User.find(params[:id])
    @user.image.purge
    redirect_to @user, notice: 'イメージを削除しました'
  end
```
2. ルーティング　config/routes.rb
```
  resources :users, except: %i[index] do
    member do
        delete :destroy_image
    end
  end
```

3. フォームに削除ボタンの作成
```
<!-- User Image -->
                    <%= image_tag(@user.image.attached? ? url_for(@user.image.variant(resize_to_limit: [400, 400])) : image_url('default.png'), class: "card-img-top") %>
                    
                    <div class="d-flex justify-content-end">
                        <% if @user.image.attached? %>
                            <%= button_to '画像の削除', destroy_image_user_path(@user), method: :delete, data: { turbo_confirm: '本当に削除しますか?' }, class: 'float-right' %>
                        <% end %>
                    </div>
```

補足
・rails7系
button_to ヘルパーを使うこと、method: :deleteを指定すること、メッセージを出すにはdata-turbo-confirmにすること
・bootstrap5を使用しているときにボタンを右に表示したいとき
Flexboxを使用する:
親要素に d-flex と justify-content-end クラスを追加して、子要素を右寄せにします。