### PR TITLE
Mobile display #42

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -35,3 +35,9 @@ label.required:after {
   font-weight: bold;
   text-decoration: none;
 }
+
+.user-thumbnail {
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
+import "bootstrap"
 import "./controllers"

--- a/app/views/families/_family.html.erb
+++ b/app/views/families/_family.html.erb
@@ -1,16 +1,20 @@
 <%= turbo_frame_tag family do %>
   <div class="card border-primary card-hover">
     <div class="card-body">
-      <h3 class="card-title">Family Name</h3>
+      <h3 class="card-title">Kazoku の名前</h3>
       <div style="display: flex; align-items: center;">
         <p class="card-subtitle fs-3"><%= family.name %></p>
       </div> 
       <%= link_to "編集", edit_family_path(@family) %>
 
-      <h3 class="card-title mt-4">Members</h3>
+      <h3 class="card-title mt-4">Kazoku のみんな</h3>
       <ul class="list-group list-group-flush">
         <% family.users.each do |user| %>
-          <li class="list-group-item"><%= link_to user.name, user_path(user), data: { turbo: false } %></li>
+          <li class="list-group-item">
+            <!-- User Image Thumbnail -->
+            <%= image_tag(user.image.attached? ? url_for(user.image.variant(resize_to_limit: [50, 50])) : image_url('default.png'), class: "user-thumbnail rounded-circle mb-2") %>
+            <div><%= link_to user.name, user_path(user), data: { turbo: false } %></div>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,11 +19,12 @@
     </div>
     <div class="offcanvas-body">
       <% if logged_in? %>
-        <%= link_to 'ファミリー', families_path(current_user.family), class: 'd-block mb-2' %>
-        <%= link_to 'イベント一覧', events_path, class: 'd-block mb-2' %>
-        <%= link_to 'イベント作成', new_event_path, class: 'd-block mb-2' %>
-        <%= link_to '思い出一覧', memories_path, class: 'd-block mb-2' %>
-        <%= link_to '思い出作成', new_memory_path, class: 'd-block mb-2' %>
+        <%= link_to 'Kazoku ページ', families_path(current_user.family), class: 'd-block mb-2' %>
+        <%= link_to 'Kazoku 招待', new_family_path, class: 'd-block mb-2' %>
+        <%= link_to 'イベント ページ', events_path, class: 'd-block mb-2' %>
+        <%= link_to 'イベント 作成', new_event_path, class: 'd-block mb-2' %>
+        <%= link_to '思い出 ページ', memories_path, class: 'd-block mb-2' %>
+        <%= link_to '思い出 作成', new_memory_path, class: 'd-block mb-2' %>
         <%= link_to 'ログアウト', logout_path, method: :delete, data: { controller: 'confirm', action: 'click->confirm#confirmLogout' }, class: 'd-block mb-2' %>
       <% else %>
         <%= link_to 'ログイン', login_path, class: 'd-block mb-2' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,39 +1,34 @@
 <!-- Navbar -->
-<!-- Remove "fixed-top" class to make navigation bar scrollable with the page -->
-<header class="header navbar navbar-expand-lg navbar-dark bg-dark shadow-sm fixed-top">
+<header class="header navbar navbar-dark bg-dark shadow-sm fixed-top">
   <div class="container px-3">
     <%= link_to root_path, class: 'navbar-brand pe-3' do %>
       Kazoku-Works
     <% end %>
-    <div id="navbarNav" class="offcanvas offcanvas-end">
-      <div class="offcanvas-header border-top">
-        <%= link_to '会員登録', new_user_path, class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex me-3' %>
-      </div>
-    </div>
-    <% if logged_in? %>
-      <% if current_user.family.present? %>
-        <% unless request.path == families_path(current_user.family) %>
-          <%= link_to '家族一覧', families_path(current_user.family), class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex me-3' %>
-        <% end %>
-        
-        <% unless request.path == events_path %>
-          <%= link_to 'イベント一覧', events_path, class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex me-3' %>
-        <% end %>
-        
-        <% unless request.path == memories_path %>
-          <%= link_to '思い出一覧', memories_path, class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex me-3' %>
-        <% end %>
-      <% end %>
 
-      <%= button_to logout_path, class: 'btn btn-secondary shadow-secondary btn-sm fs-sm rounded d-none d-lg-inline-flex', method: :delete, data: { controller: 'confirm', action: 'click->confirm#confirmLogout' } do %>
-        ログアウト
+    <!-- Hamburger icon -->
+    <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu" aria-controls="offcanvasMenu">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  </div>
+
+  <!-- Offcanvas Menu -->
+  <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasMenu">
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title">Menu</h5>
+      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+      <% if logged_in? %>
+        <%= link_to 'ファミリー', families_path(current_user.family), class: 'd-block mb-2' %>
+        <%= link_to 'イベント一覧', events_path, class: 'd-block mb-2' %>
+        <%= link_to 'イベント作成', new_event_path, class: 'd-block mb-2' %>
+        <%= link_to '思い出一覧', memories_path, class: 'd-block mb-2' %>
+        <%= link_to '思い出作成', new_memory_path, class: 'd-block mb-2' %>
+        <%= link_to 'ログアウト', logout_path, method: :delete, data: { controller: 'confirm', action: 'click->confirm#confirmLogout' }, class: 'd-block mb-2' %>
+      <% else %>
+        <%= link_to 'ログイン', login_path, class: 'd-block mb-2' %>
+        <%= link_to '会員登録', new_user_path, class: 'd-block mb-2' %>
       <% end %>
-    <% else %>
-      <div class="form-check form-switch mode-switch pe-lg-1 ms-auto me-4" data-bs-toggle="mode">
-        <%= link_to 'ログイン', login_path, class: 'btn btn-secondary shadow-secondary btn-sm fs-sm rounded d-none d-lg-inline-flex' %>
-      </div>
-        <%= link_to '会員登録', new_user_path, class: 'btn btn-primary shadow-primary btn-sm fs-sm rounded d-none d-lg-inline-flex' %>
-      </div>
-    <% end %>
+    </div>
   </div>
 </header>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.3.0",
+    "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.5",
     "esbuild": "^0.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,11 @@
   resolved "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.3.0.tgz"
   integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@rails/actioncable@^7.0":
   version "7.0.4"
   resolved "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.0.4.tgz"


### PR DESCRIPTION
1. スマホログイン時にヘッダーにリンクが表示されない
d-none は要素を非表示にし、d-lg-inline-flex はlg（large）サイズ以上のデバイスでのみ要素をインラインフレックスとして表示する。そのため、スマホのような小さい画面サイズのデバイスでは、これらの要素が非表示になってしまう。
`<%= link_to 'ログイン', login_path, class: 'btn btn-secondary shadow-secondary btn-sm fs-sm rounded' %>`
変更

2. ログイン後のヘッダーのリンクを変更
bootstrapのコンポーネントを使ってハンバーガーメニューへ変更。

Bootstrap 5のJavaScriptを使用する場合、@popperjs/coreもインストールする必要があったため
`yarn add @popperjs/core`

3. 家族一覧ページでの見栄え（userサムネ画像)
デザインの変更。default.pngのイメージだけサイズの抑制ができなかったためscssへ追加
```
.user-thumbnail {
  width: 50px;
  height: 50px;
  object-fit: cover;
}
```
